### PR TITLE
Add hardcoded v2 language strings to translation files

### DIFF
--- a/en.json
+++ b/en.json
@@ -25,6 +25,37 @@
       "par1": "Found a bug ? Have questions about the site ? Join the <a href=\"https://discord.gg/ZZFS8YT\" target=\"_blank\">Discord server</a>",
       "par2": "For business/PR inquiries, write an email at <a href=\"mailto:contact@oengus.io\" target=\"_blank\">contact@oengus.io</a>. We will only respond to emails written in English.",
       "title": "Contact"
+    },
+    "privacy": {
+      "title": "Privacy Policy",
+      "par1": "At Oengus, accessible from {{oengusLink}}, one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by Oengus and how we use it.",
+      "par2": "If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us.",
+      "log": {
+        "title": "Log Files",
+        "par1": "Oengus follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services' analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. These are not linked to any information that is personally identifiable. The purpose of the information is for analyzing trends, administering the site, tracking users' movement on the website, and gathering demographic information."
+      },
+      "cookies": {
+        "title": "Cookies and Web Beacons",
+        "par1": "Like any other website, Oengus uses 'cookies'. These cookies are used to store information including visitors' preferences, and the pages on the website that the visitor accessed or visited. The information is used to optimize the users' experience by customizing our web page content based on visitors' browser type and/or other information."
+      },
+      "thirdParty": {
+        "title": "Third Party Privacy Policies",
+        "par1": "Oengus's Privacy Policy does not apply to other advertisers or websites.",
+        "par2": "You can choose to disable cookies through your individual browser options. To know more detailed information about cookie management with specific web browsers, it can be found at the browsers' respective websites."
+      },
+      "children": {
+        "title": "Children's Information",
+        "par1": "Another part of our priority is adding protection for children while using the internet. We encourage parents and guardians to observe, participate in, and/or monitor and guide their online activity.",
+        "par2": "Oengus does not knowingly collect any Personal Identifiable Information from children under the age of 13. If you think that your child provided this kind of information on our website, we strongly encourage you to contact us immediately and we will do our best efforts to promptly remove such information from our records."
+      },
+      "online": {
+        "title": "Online Privacy Policy Only",
+        "par1": "This Privacy Policy applies only to our online activities and is valid for visitors to our website with regards to the information that they shared and/or collect in Oengus. This policy is not applicable to any information collected offline or via channels other than this website."
+      },
+      "consent": {
+        "title": "Consent",
+        "par1": "By using our website, you hereby consent to our Privacy Policy and agree to its Terms and Conditions."
+      }
     }
   },
   "action": {
@@ -146,7 +177,8 @@
   },
   "footer": {
     "donate": "If you enjoy Oengus, please consider <a href=\"{{donationLink}}\" target=\"_blank\">making a donation</a>",
-    "text": "All times are converted to your timezone. Detected timezone: {{timezone}}"
+    "text": "All times are converted to your timezone. Detected timezone: {{timezone}}",
+    "v1Link": "View this page on Oengus v1"
   },
   "global": {
     "emu": "[Emu]",
@@ -373,6 +405,7 @@
         "estimate": "Estimate",
         "game": "Game",
         "placeholder": "Drop any run from the left table to this one. This text will automatically disappear as soon as one run is in the schedule.",
+        "link": "Link",
         "runner": "Runner(s)",
         "setup": "Setup time",
         "time": "Time",


### PR DESCRIPTION
Includes language strings in English for Privacy statements, the v1 button, and the new Run Link on the schedule page